### PR TITLE
Specify required python version in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ into various G1RegionSize's (2mb-32mb by powers of 2).
 ```
 
 ## How to run
+Use python 2.6 (running with 2.7 will throw an error currently).
 The start and end dates are optional and can be any format gnuplot understands.
 The second argument will be used as the base name for the created png files.
 


### PR DESCRIPTION
Looks like `dateutil` doesn't exist in python2.7. Just adding a line to the README for now so people don't think the tool is broken.
Error for reference:

```
Traceback (most recent call last):
  File "gc_log_visualizer.py", line 7, in <module>
    import dateutil.parser
ImportError: No module named dateutil.parser
```
