### PR TITLE
Add alternative opt for JVM unified logging framework and update regionsize_vs_objectsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The shell script `regionsize_vs_objectsize.sh` will take a gc.log
 as input and return the percent of Humongous Objects that would fit
 into various G1RegionSize's (2mb-32mb by powers of 2).
 
+If JVM Unified Logging Framework is enabled, this will not work out of the box, we will need to enable printing of information about adaptive generation size. 
+See [gc log preparation](https://github.com/HubSpot/gc_log_visualizer#gc-log-preparation) for adding GC logs to make this work.
+
 ```
   ./regionsize_vs_objectsize.sh <gc.log>
   1986 humongous objects referenced in <gc.log>
@@ -51,6 +54,8 @@ The following gc params are required for full functionality.
 ```
   -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintAdaptiveSizePolicy
 ```
+_For JVM Unified Logging Framework, corresponding options can be found [here](https://docs.oracle.com/javase/9/tools/java.htm#JSWOR-GUID-9569449C-525F-4474-972C-4C1F63D5C357).
+For example, for legacy GC flag `-XX:PrintAdaptiveSizePolicy` (used to add log lines to calculate humongous objects with `regionsize_vs_objectsize.sh`) instead use `-Xlog:ergo*=debug`._
 
 ## required python libs
 The python libs that are required can be found in the setup.py

--- a/regionsize_vs_objectsize.sh
+++ b/regionsize_vs_objectsize.sh
@@ -7,11 +7,11 @@ if [ -z "${log}" ] ; then
 fi
 
 total=`grep "source: concurrent humongous allocation" ${log}  | wc -l`
-fit2mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\) bytes.*/\1/' | awk '{if($1<1048576) print}' | wc -l`
-fit4mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\) bytes.*/\1/' | awk '{if($1<2097152) print}' | wc -l`
-fit8mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\) bytes.*/\1/' | awk '{if($1<4194304) print}' | wc -l`
-fit16mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\) bytes.*/\1/' | awk '{if($1<8388608) print}' | wc -l`
-fit32mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\) bytes.*/\1/' | awk '{if($1<16777216) print}' | wc -l`
+fit2mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\).*/\1/' | awk '{if($1<1048576) print}' | wc -l`
+fit4mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\).*/\1/' | awk '{if($1<2097152) print}' | wc -l`
+fit8mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\).*/\1/' | awk '{if($1<4194304) print}' | wc -l`
+fit16mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\).*/\1/' | awk '{if($1<8388608) print}' | wc -l`
+fit32mb=`grep "source: concurrent humongous allocation" ${log} | sed 's/.*allocation request: \([0-9]*\).*/\1/' | awk '{if($1<16777216) print}' | wc -l`
 
 echo "${total} humongous objects referenced in ${log}"
 echo `echo ${fit2mb} ${total} | awk '{printf "%2.0f", 100 * $1 / $2}'`% would not be humongous with a 2mb g1 region size


### PR DESCRIPTION
- Update README to add information about corresponding JVM unified logging framework options
- Update `regionsize_vs_objectsize.sh` for jvm logging framework